### PR TITLE
Macos Issue #45

### DIFF
--- a/macos/Classes/MainFlutterWindowManipulator.swift
+++ b/macos/Classes/MainFlutterWindowManipulator.swift
@@ -388,9 +388,11 @@ public class MainFlutterWindowManipulator {
     }
     
     public static func addToolbar() {
-        let newToolbar = NSToolbar()
-        
-        self.mainFlutterWindow?.toolbar = newToolbar
+        if #available(macOS 10.13, *) {
+            let newToolbar = NSToolbar()
+
+            self.mainFlutterWindow?.toolbar = newToolbar
+        }
     }
     
     public static func removeToolbar() {


### PR DESCRIPTION
This fixes #45 by wrapping the code within `addToolbar()` function in `macos/Classes/MainFlutterWindowManipulator.swift` with
```swift
if #available(macOS 10.13, *) {
//...
}
```